### PR TITLE
fix(digital-wallets): Fix Apple Pay session spelling

### DIFF
--- a/lib/Gr4vyConfig.php
+++ b/lib/Gr4vyConfig.php
@@ -451,7 +451,7 @@ class Gr4vyConfig
         $response = $this->post("/reports/". $report_id . "/executions/" . $report_execution_id . "/url", $request);
         return $response;
     }
-    public function newApplePaySesson($request = array()) {
+    public function newApplePaySession($request = array()) {
         $response = $this->post("/digital-wallets/apple/session/", $request);
         return $response;
     }


### PR DESCRIPTION
Fixes a spelling mistake in the previous update.