### PR TITLE
fix(spec): flatten the report spec union so it serialises

### DIFF
--- a/.speakeasy/overlays/fix-report-spec-union.yaml
+++ b/.speakeasy/overlays/fix-report-spec-union.yaml
@@ -1,0 +1,38 @@
+overlay: 1.0.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Flatten the report spec union so it cannot serialize to null
+  version: 0.0.1
+# `ReportCreate.spec` is a discriminated `oneOf` of four report-spec variants
+# (transactions / transaction_retries / detailed_settlement / accounts_receivables),
+# each just `{ model: <const>, params: <free-form object> }`. Speakeasy renders that
+# as a C# union whose JSON writer emits a body only when one of the variant members
+# is set — so a Spec built without a body serialises the *required* `spec` field as
+# `null`, which the API's report validator cannot handle (Sentry CORE-API-3AE:
+# AttributeError on `values.get("spec", {}).get("model")`).
+#
+# The variants are structurally identical (params is a free-form object in every
+# case), so the union adds no type safety on the wire. Collapse it into a single
+# required object: `spec` then generates a plain model with required `model` +
+# `params` that can never be empty/null and forces the caller to set `model`.
+actions:
+  - target: $.components.schemas.ReportCreate.properties.spec.oneOf
+    remove: true
+  - target: $.components.schemas.ReportCreate.properties.spec.discriminator
+    remove: true
+  - target: $.components.schemas.ReportCreate.properties.spec
+    update:
+      type: object
+      required:
+        - model
+        - params
+      properties:
+        model:
+          type: string
+          description: >-
+            The report model. One of `transactions`, `transaction_retries`,
+            `detailed_settlement`, `accounts_receivables`.
+        params:
+          type: object
+          additionalProperties: true
+          description: The parameters for the report, specific to the model.

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -14,6 +14,7 @@ sources:
             - location: ./.speakeasy/overlays/fix-checkout-session-body.yaml
             - location: ./.speakeasy/overlays/fix-remove-unwanted-headers.yaml
             - location: ./.speakeasy/overlays/fix-add-x-forwarded-for-header.yaml
+            - location: ./.speakeasy/overlays/fix-report-spec-union.yaml
         registry:
             location: registry.speakeasyapi.dev/gr4vy/gr4vy/openapi
 targets:


### PR DESCRIPTION
## Why

The generated PHP `src/Utils/UnionHandler.php` cannot **serialize** the discriminated `ReportCreate.spec` `oneOf`. As a result `$sdk->reports->create(...)` throws `TypeError: Cannot access offset of type string on string` *before the request is sent* — so **`POST /reports` is unusable** in the PHP SDK. (Surfaced by the E2E suite in #221, where the create test currently skips with this reason.)

The four spec variants (`transactions` / `transaction_retries` / `detailed_settlement` / `accounts_receivables`) are structurally identical — `model` const + a free-form `params` object — so the union adds no wire-level type safety. This is the same issue, and the same fix, as the C# SDK (`fix-report-spec-union.yaml` there).

## What

Adds `.speakeasy/overlays/fix-report-spec-union.yaml` (registered in `workflow.yaml`) which removes the `oneOf` + `discriminator` from `ReportCreate.spec` and replaces it with a single required object:

```yaml
spec:
  type: object
  required: [model, params]
  properties:
    model:  { type: string }
    params: { type: object, additionalProperties: true }
```

On the next SDK regen, `ReportCreate.spec` becomes a plain serialisable object, `reports.create` works, and the E2E suite's `POST /reports` test (currently skipped in #221) reaches a real 2xx — taking endpoint coverage to 107/107.

> Note: this fixes the **request-body** serialization for reports. The broader UnionHandler serialize bug (it also crashes when rendering 4xx error bodies whose `details` is empty) is tracked separately as an upstream Speakeasy fix.

Opened as a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)