### PR TITLE
fix(gen): flatten autoload-dev so SDK regeneration validates

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -34,8 +34,7 @@ php:
   additionalDependencies:
     autoload: {}
     autoload-dev:
-      psr-4:
-        Gr4vy\Tests\: Tests/
+      Gr4vy\Tests\: Tests/
     require:
       lcobucci/jwt: ^5.5.0
       paragonie/sodium_compat_ext_sodium: '>= 1'


### PR DESCRIPTION
## Why

The \`Generate SDK\` workflow has been failing on \`main\` since #221 merged. Run [26776156379](https://github.com/gr4vy/gr4vy-php/actions/runs/26776156379) dies at **Setup Environment**:

> validation error: gen.yaml validation error for php: additionalDependencies.autoload-dev.psr-4 must be a string

## Root cause

#221 added test-only autoloading to \`.speakeasy/gen.yaml\` in Composer's nested shape:

\`\`\`yaml
autoload-dev:
  psr-4:
    Gr4vy\Tests\: Tests/
\`\`\`

But Speakeasy's \`php.additionalDependencies.autoload-dev\` is a **flat namespace→path map** — it renders the \`psr-4:\` nesting into \`composer.json\` itself. The generator therefore parsed \`psr-4\` as a *namespace* whose value must be a path string, found a map, and aborted before generating.

## Fix

\`\`\`yaml
autoload-dev:
  Gr4vy\Tests\: Tests/
\`\`\`

The generated \`composer.json\` \`autoload-dev\` block (and the \`Gr4vy\Tests\ → Tests/\` mapping the E2E suite relies on) is unchanged — only the gen.yaml source shape is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)