### PR TITLE
ci: shard E2E by directory instead of a regen-managed phpunit.xml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,10 @@ on:
     - cron: 30 8 * * 1-5
 
 jobs:
-  # E2E suites, sharded by test-suite so wall-clock stays low. Each shard
+  # E2E suites, sharded by directory so wall-clock stays low. Each shard
   # provisions its own merchant accounts, so they are fully independent.
+  # The shard map lives here (not in phpunit.xml, which Speakeasy regenerates)
+  # — a positional path makes PHPUnit run just that directory.
   e2e:
     name: e2e (${{ matrix.shard }})
     runs-on: ubuntu-latest
@@ -21,10 +23,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard:
-          - flows
-          - processing
-          - backoffice
+        include:
+          - { shard: flows, path: Tests/Flows }
+          - { shard: processing, path: Tests/Processing }
+          - { shard: backoffice, path: Tests/Backoffice }
 
     steps:
       - name: Check out the repo
@@ -54,7 +56,7 @@ jobs:
             echo "::error::PRIVATE_KEY is not set on a trusted ref — failing instead of silently skipping the live suite."
             exit 1
           fi
-          composer test -- --testsuite ${{ matrix.shard }}
+          composer test -- ${{ matrix.path }}
 
   # Offline tests (JWT + webhook signing) across the supported PHP versions —
   # fast cross-version sanity that needs no sandbox.
@@ -85,7 +87,7 @@ jobs:
       - name: Run offline suite
         env:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-        run: composer test -- --testsuite offline
+        run: composer test -- Tests/AuthTest.php Tests/WebhooksTest.php
 
   # Single stable required check. Branch rulesets should require THIS context
   # (not the per-shard matrix jobs, whose names change when shards are added).

--- a/TESTING.md
+++ b/TESTING.md
@@ -29,11 +29,11 @@ composer install
 # Everything (offline unit tests + live E2E)
 composer test
 
-# A single shard / suite
-composer test -- --testsuite flows
-composer test -- --testsuite processing
-composer test -- --testsuite backoffice
-composer test -- --testsuite offline
+# A single shard (just pass the directory — PHPUnit runs that path)
+composer test -- Tests/Flows
+composer test -- Tests/Processing
+composer test -- Tests/Backoffice
+composer test -- Tests/AuthTest.php Tests/WebhooksTest.php   # offline
 
 # A single test class or method
 composer test -- --filter TransactionLifecycleTest
@@ -65,8 +65,10 @@ Tests/
 
 Each E2E test **class** provisions its own merchant account (random id) with a
 `mock-card` payment service in `setUpBeforeClass()`, so classes share no state and
-the suite is safe to shard. The four PHPUnit `<testsuite>`s in `phpunit.xml`
-double as **CI shards** (`--testsuite flows|processing|backoffice|offline`).
+the suite is safe to shard. CI shards by **directory** — each job runs one of
+`Tests/Flows`, `Tests/Processing`, `Tests/Backoffice` (and the offline pair) as a
+positional PHPUnit path. The shard map lives in `.github/workflows/ci.yaml`, not
+in `phpunit.xml` (which Speakeasy regenerates), so regeneration can't break it.
 
 ### The mock-card connector ("test mode")
 

--- a/Tests/Utils/TestEnvironment.php
+++ b/Tests/Utils/TestEnvironment.php
@@ -25,7 +25,7 @@ use Psr\Http\Message\ResponseInterface;
  *       tolerates forward-compatible payloads (disable with GR4VY_NO_INJECT), and
  *   (b) when GR4VY_TRACK_HTTP is set, records the method + path of every outgoing
  *       request to coverage/http/*.jsonl so the endpoint-coverage report can
- *       measure reach from real HTTP calls (see scripts/endpoint-coverage.mjs).
+ *       measure reach from real HTTP calls (see scripts/endpoint-coverage.php).
  */
 final class TestEnvironment
 {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,21 +4,9 @@
          bootstrap="vendor/autoload.php"
          colors="true"
 >
-    <!-- Suites double as CI shards (run one with the testsuite flag, e.g.
-         "flows"). With no testsuite flag, every suite runs (full local suite). -->
     <testsuites>
-        <testsuite name="flows">
-            <directory suffix="Test.php">./Tests/Flows</directory>
-        </testsuite>
-        <testsuite name="processing">
-            <directory suffix="Test.php">./Tests/Processing</directory>
-        </testsuite>
-        <testsuite name="backoffice">
-            <directory suffix="Test.php">./Tests/Backoffice</directory>
-        </testsuite>
-        <testsuite name="offline">
-            <file>./Tests/AuthTest.php</file>
-            <file>./Tests/WebhooksTest.php</file>
+        <testsuite name="Test Suite">
+            <directory suffix="Test.php">./Tests</directory>
         </testsuite>
     </testsuites>
     <source>


### PR DESCRIPTION
## Why

The 1.5.87 SDK regen (#224) turned every CI shard red with **\`No tests executed!\`**. Root cause: \`phpunit.xml\` is a **Speakeasy-managed file** (it's in \`.speakeasy/gen.lock\`), so the custom \`flows\`/\`processing\`/\`backoffice\`/\`offline\` \`<testsuite>\`s added in #221 get reverted to the generated single-\`"Test Suite"\` layout on every regen. Each CI shard ran \`--testsuite <name>\`, so after the revert every shard matched zero tests and exited 1.

Guarding the file with \`.genignore\` would work, but it leaves a Speakeasy-owned file permanently customised and easy to trip over again. Better to stop putting our config in a file we don't own.

## Fix

Move the shard map out of \`phpunit.xml\` and into \`ci.yaml\` — a place Speakeasy doesn't manage:

- The e2e matrix now carries directories (\`Tests/Flows\`, \`Tests/Processing\`, \`Tests/Backoffice\`) and runs each as a **positional PHPUnit path** (\`composer test -- Tests/Flows\`), which overrides the configured testsuite. Job names stay \`e2e (flows)\` etc. via \`matrix.include\`, so \`ci-complete\` and branch protection are unaffected.
- The offline job runs the two files by path.
- \`phpunit.xml\` reverts to the generated default, so **regeneration is now a no-op on it** — nothing to protect, no \`.genignore\`.

Also fixes a stale \`scripts/endpoint-coverage.mjs\` → \`.php\` docblock reference that #223's squash-merge missed.

## Net effect

After this merges, an SDK regen leaves \`phpunit.xml\` untouched (it already matches the template) and the sharded CI keeps working. Local runs become \`composer test -- Tests/Flows\` (documented in TESTING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)