### PR TITLE
feat(auth): add getEmbedTokenWithCheckoutSession helper

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -1,0 +1,2 @@
+src/Auth.php
+Tests/AuthTest.php

--- a/README.md
+++ b/README.md
@@ -144,6 +144,41 @@ $token = $token = Auth::getEmbedToken(
 > **Note:** This will only create a token once. Use `Auth::withToken` with our SDK to dynamically generate a token
 > for every request.
 
+### Attaching a checkout session automatically
+
+For Embed, it is recommended to attach a checkout session to every transaction. The
+`Auth::getEmbedTokenWithCheckoutSession` helper creates a checkout session using your SDK client and
+returns an Embed token with the resulting `checkout_session_id` already pinned, in a single call.
+
+```php
+use Gr4vy;
+use Gr4vy\Auth;
+
+// Loaded the key from a file, env variable,
+// or anywhere else
+$privateKey = "...";
+
+$sdk = Gr4vy\SDK::builder()
+    ->setId('example')
+    ->setServer('sandbox')
+    ->setSecuritySource(Auth::withToken($privateKey))
+    ->setMerchantAccountId('default')
+    ->build();
+
+$token = Auth::getEmbedTokenWithCheckoutSession(
+    client: $sdk,
+    privateKey: $privateKey,
+    embedParams: [
+        "amount" => 1299,
+        "currency" => "AUD",
+    ],
+);
+```
+
+You can optionally pass a `checkoutSession` body (a `CheckoutSessionCreate`) to seed the session
+(for example with cart items or metadata), and a `merchantAccountId` to override the client's
+configured merchant account.
+
 ## Merchant account ID selection
 
 Depending on the key used, you might need to explicitly define a merchant account ID to use. In our API, 

--- a/README.md
+++ b/README.md
@@ -126,14 +126,14 @@ $sdk = Gr4vy\SDK::builder()
     ->setMerchantAccountId('default')
     ->build();
 
-$response = $sdk->checkout_sessions.create();
+$response = $sdk->checkoutSessions->create();
 
 $embedParams = [
     "amount" => 1299,
     "currency" => "AUD",
 ];
 
-$token = $token = Auth::getEmbedToken(
+$token = Auth::getEmbedToken(
     privateKey: $privateKey,
     expiresIn: '+1 hour',
     checkoutSessionId: $response->checkoutSession->id,

--- a/README.md
+++ b/README.md
@@ -151,14 +151,14 @@ For Embed, it is recommended to attach a checkout session to every transaction. 
 returns an Embed token with the resulting `checkout_session_id` already pinned, in a single call.
 
 ```php
-use Gr4vy;
 use Gr4vy\Auth;
+use Gr4vy\SDK;
 
 // Loaded the key from a file, env variable,
 // or anywhere else
 $privateKey = "...";
 
-$sdk = Gr4vy\SDK::builder()
+$sdk = SDK::builder()
     ->setId('example')
     ->setServer('sandbox')
     ->setSecuritySource(Auth::withToken($privateKey))

--- a/Tests/AuthTest.php
+++ b/Tests/AuthTest.php
@@ -163,6 +163,25 @@ EOD;
         $this->assertEquals($this->embedParams, $decoded['payload']['embed']);
     }
 
+    public function test_get_embed_token_with_checkout_session_throws_on_missing_id(): void
+    {
+        $response = $this->createMock(CreateCheckoutSessionResponse::class);
+        $response->checkoutSession = null;
+
+        $checkoutSessions = $this->createMock(CheckoutSessions::class);
+        $checkoutSessions->expects($this->once())
+            ->method('create')
+            ->willReturn($response);
+
+        $client = $this->createMock(SDK::class);
+        $client->checkoutSessions = $checkoutSessions;
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/without an ID/');
+
+        Auth::getEmbedTokenWithCheckoutSession($client, $this->privateKey);
+    }
+
     public function test_update_token_resigns_with_new_expiration(): void
     {
         $originalToken = Auth::getToken($this->privateKey, [JWTScope::READ_ALL], '+1 minute');

--- a/Tests/AuthTest.php
+++ b/Tests/AuthTest.php
@@ -3,7 +3,11 @@
 declare(strict_types=1);
 
 use Gr4vy\Auth;
+use Gr4vy\CheckoutSession;
+use Gr4vy\CheckoutSessions;
+use Gr4vy\CreateCheckoutSessionResponse;
 use Gr4vy\JWTScope;
+use Gr4vy\SDK;
 use PHPUnit\Framework\TestCase;
 
 final class AuthTest extends TestCase
@@ -128,6 +132,35 @@ EOD;
         $decoded = $this->decodeJwt($token);
 
         $this->assertEquals($this->checkoutSessionId, $decoded['payload']['checkout_session_id']);
+    }
+
+    public function test_get_embed_token_with_checkout_session_pins_created_id(): void
+    {
+        $session = $this->createMock(CheckoutSession::class);
+        $session->id = $this->checkoutSessionId;
+
+        $response = $this->createMock(CreateCheckoutSessionResponse::class);
+        $response->checkoutSession = $session;
+
+        $checkoutSessions = $this->createMock(CheckoutSessions::class);
+        $checkoutSessions->expects($this->once())
+            ->method('create')
+            ->willReturn($response);
+
+        $client = $this->createMock(SDK::class);
+        $client->checkoutSessions = $checkoutSessions;
+
+        $token = Auth::getEmbedTokenWithCheckoutSession(
+            $client,
+            $this->privateKey,
+            $this->embedParams
+        );
+
+        $decoded = $this->decodeJwt($token);
+
+        $this->assertEquals(['embed'], $decoded['payload']['scopes']);
+        $this->assertEquals($this->checkoutSessionId, $decoded['payload']['checkout_session_id']);
+        $this->assertEquals($this->embedParams, $decoded['payload']['embed']);
     }
 
     public function test_update_token_resigns_with_new_expiration(): void

--- a/Tests/Flows/TransactionLifecycleTest.php
+++ b/Tests/Flows/TransactionLifecycleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Gr4vy\Tests\Flows;
 
+use Gr4vy\CaptureCollection;
 use Gr4vy\CaptureTransactionRequest;
 use Gr4vy\Tests\Utils\CheckoutFields;
 use Gr4vy\Tests\Utils\MerchantTestCase;
@@ -74,6 +75,36 @@ final class TransactionLifecycleTest extends MerchantTestCase
             description: 'transaction voided',
         );
         $this->assertStringContainsString('void', $voided->status);
+    }
+
+    #[Test]
+    public function capture_list_and_get(): void
+    {
+        $sdk = $this->sdk();
+
+        $txn = CheckoutFields::authorize($sdk, amount: 4500, currency: 'USD');
+        $this->assertSame('authorization_succeeded', $txn->status);
+
+        $sdk->transactions->capture(new CaptureTransactionRequest(
+            transactionId: $txn->id,
+            transactionCaptureCreate: new TransactionCaptureCreate(amount: 4500),
+        ));
+
+        // Captures are eventually consistent; poll until one appears.
+        $collection = Poll::until(
+            fn () => $sdk->transactions->captures->list($txn->id)->captureCollection,
+            fn (?CaptureCollection $c) => $c !== null && count($c->items) >= 1,
+            description: 'capture to appear',
+        );
+        $this->assertNotNull($collection);
+        $this->assertGreaterThanOrEqual(1, count($collection->items));
+
+        $captureId = $collection->items[0]->id;
+        $this->assertNotEmpty($captureId);
+
+        $fetched = $sdk->transactions->captures->get($txn->id, $captureId)->capture;
+        $this->assertNotNull($fetched);
+        $this->assertSame($captureId, $fetched->id);
     }
 
     #[Test]

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -245,6 +245,9 @@ class Auth
         $response = $client->checkoutSessions->create(checkoutSessionCreate: $checkoutSession, merchantAccountId: $merchantAccountId);
 
         $checkoutSessionId = $response->checkoutSession?->id;
+        if (empty($checkoutSessionId)) {
+            throw new \RuntimeException('Checkout session was created without an ID.');
+        }
 
         return self::getEmbedToken(privateKey: $privateKey, expiresIn: $expiresIn, checkoutSessionId: $checkoutSessionId, embedParams: $embedParams);
     }

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -225,6 +225,31 @@ class Auth
     }
 
     /**
+     * Creates a checkout session and returns an Embed token with its ID pinned.
+     *
+     * This is a convenience wrapper around getEmbedToken for the common Embed flow
+     * where every transaction should be tied to a checkout session. It uses the
+     * provided (already authenticated) SDK client to create the checkout session,
+     * then signs an Embed token that pins the resulting checkout_session_id.
+     *
+     * @param  SDK  $client  An authenticated Gr4vy SDK client.
+     * @param  non-empty-string  $privateKey  The private key to sign the JWT.
+     * @param  array<string,mixed>|null  $embedParams  Optional embed parameters.
+     * @param  ?CheckoutSessionCreate  $checkoutSession  Optional checkout session body to seed cart items, metadata, and so on.
+     * @param  string|null  $merchantAccountId  Optional merchant account ID override.
+     * @param  string  $expiresIn  The expiration time (default "+1 hour").
+     * @return string The generated embed JWT token.
+     */
+    public static function getEmbedTokenWithCheckoutSession(SDK $client, string $privateKey, ?array $embedParams = null, ?CheckoutSessionCreate $checkoutSession = null, ?string $merchantAccountId = null, string $expiresIn = '+1 hour'): string
+    {
+        $response = $client->checkoutSessions->create(checkoutSessionCreate: $checkoutSession, merchantAccountId: $merchantAccountId);
+
+        $checkoutSessionId = $response->checkoutSession?->id;
+
+        return self::getEmbedToken(privateKey: $privateKey, expiresIn: $expiresIn, checkoutSessionId: $checkoutSessionId, embedParams: $embedParams);
+    }
+
+    /**
      * Calculates the key ID (kid) for a given private key.
      *
      * @param  non-empty-string  $privateKey  The private key.


### PR DESCRIPTION
## What

Adds an opt-in `getEmbedTokenWithCheckoutSession` helper (idiomatic per language) that creates a checkout session via the SDK client and returns an Embed token with the resulting `checkout_session_id` already pinned — in a single call.

This makes it neat for merchants to ensure **every Embed transaction is tied to a checkout session**, without manually creating the session and threading its ID into the token call.

## Details

- **Non-breaking**: the existing `getEmbedToken` signature is unchanged. Passing the SDK client into the new helper is the opt-in.
- Accepts an optional checkout session body (cart items, metadata, etc.) and an optional merchant-account override; defaults to an empty session using the client's configured merchant account.
- The hand-written auth source and its test are now protected from Speakeasy regeneration via `.genignore`.
- New unit test covers: a checkout session is created exactly once and the returned token carries the `embed` scope and the pinned `checkout_session_id`.
- README "Embed token generation" section documents the new helper (these sections live outside Speakeasy's managed `<!-- Start/End -->` regions, so they survive regen).

Docs PR (token quickstart + JWT guide) is in `gr4vy-docs-mintlify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
