### PR TITLE
test: cover API key pairs and transaction refund-settlements endpoints

### DIFF
--- a/Tests/Backoffice/ApiKeyPairsTest.php
+++ b/Tests/Backoffice/ApiKeyPairsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gr4vy\Tests\Backoffice;
+
+use Gr4vy\APIKeyPairCreate;
+use Gr4vy\APIKeyPairUpdate;
+use Gr4vy\Tests\Utils\MerchantTestCase;
+use Gr4vy\Tests\Utils\Reach;
+use Gr4vy\Tests\Utils\TestEnvironment;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * API key pairs: list is a happy path; create/get/update/delete are reached at
+ * the request level. create needs a real role to assign — the mock env has no
+ * role we can reference, so a non-existent role id is rejected with a 4xx (the
+ * endpoint is still reached). get/update/delete target a non-existent id and 404.
+ */
+final class ApiKeyPairsTest extends MerchantTestCase
+{
+    #[Test]
+    public function list_is_happy_path(): void
+    {
+        // API key pairs are an account-level resource (like merchant accounts),
+        // not merchant-scoped, so drive them with an unscoped (admin) client.
+        $sdk = TestEnvironment::createClient($this->merchant()->privateKey);
+        $this->firstOf($sdk->apiKeyPairs->list());
+        $this->addToAssertionCount(1);
+    }
+
+    #[Test]
+    public function create_get_update_delete_are_reached(): void
+    {
+        $sdk = TestEnvironment::createClient($this->merchant()->privateKey);
+
+        // create: a non-existent role id is rejected with a 4xx, but the request
+        // still reaches the endpoint (we cannot provision a real role here).
+        Reach::reaches(
+            fn () => $sdk->apiKeyPairs->create(new APIKeyPairCreate(
+                displayName: 'coverage-probe',
+                roleIds: [self::MISSING_ID],
+            )),
+            'apiKeyPairs.create',
+        );
+        Reach::reaches(fn () => $sdk->apiKeyPairs->get(self::MISSING_ID), 'apiKeyPairs.get');
+        Reach::reaches(
+            fn () => $sdk->apiKeyPairs->update(new APIKeyPairUpdate(displayName: 'renamed'), self::MISSING_ID),
+            'apiKeyPairs.update',
+        );
+        Reach::reaches(fn () => $sdk->apiKeyPairs->delete(self::MISSING_ID), 'apiKeyPairs.delete');
+    }
+}

--- a/Tests/Processing/TransactionsTest.php
+++ b/Tests/Processing/TransactionsTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Transactions resource: create/get/list/update plus the read sub-resources
- * (actions, events, settlements) and the cancel action. Capture / void / refund
+ * (actions, events, settlements, refund-settlements) and the cancel action. Capture / void / refund
  * / sync are covered as a story in {@see \Gr4vy\Tests\Flows\TransactionLifecycleTest}.
  */
 final class TransactionsTest extends MerchantTestCase
@@ -71,6 +71,15 @@ final class TransactionsTest extends MerchantTestCase
         Reach::reaches(
             fn () => $sdk->transactions->settlements->get($txn->id, self::MISSING_ID),
             'transactions.settlements.get',
+        );
+
+        $refundSettlements = $sdk->transactions->refundSettlements->list($txn->id)->refundSettlements;
+        $this->assertNotNull($refundSettlements);
+
+        // A specific refund settlement needs a settled transaction we cannot force here.
+        Reach::reaches(
+            fn () => $sdk->transactions->refundSettlements->get($txn->id, self::MISSING_ID),
+            'transactions.refundSettlements.get',
         );
     }
 


### PR DESCRIPTION
## Coverage gap

Two sets of generated endpoints had no test, so CI's endpoint-coverage check (an endpoint counts as covered only when a real HTTP request reaches the server) flagged them as uncovered:

- **API key pairs** (`src/ApiKeyPairs.php`): `create` / `list` / `get` / `update` / `delete` — 5 endpoints, zero tests.
- **Transaction refund-settlements** (`src/TransactionsRefundSettlements.php`): `list` and `get` — the sub-resource under `GET /transactions/{transaction_id}/refund-settlements`.

## Design

Mirrors the conventions of the existing suites (`PayoutsTest`, `MerchantAccountsTest`, and the `settlements` sub-resource in `TransactionsTest`).

### `Tests/Backoffice/ApiKeyPairsTest.php` (new)
- **list** — happy path: iterated so a real request is sent, asserted reached.
- **create / get / update / delete** — driven through the repo's `Reach` helper. A full happy path is not achievable in the mock env (create needs a real role to assign), so each request reaches the endpoint and is rejected with a documented 4xx. `create` uses a non-existent role id; `get`/`update`/`delete` use the `MISSING_ID` constant.

API key pairs are an **account-level** resource (like merchant accounts), so the tests use an unscoped (admin) client via `TestEnvironment::createClient(...)` rather than the merchant-scoped `$this->sdk()`.

### `Tests/Processing/TransactionsTest.php` (extended)
Added to `read_subresources`, alongside the existing `settlements` coverage:
- **refundSettlements->list(txnId)** — happy path (empty until the transaction settles).
- **refundSettlements->get(txnId, MISSING_ID)** — reached via `Reach`; a specific refund settlement needs a settled transaction we cannot force.

Only test files change; no generated code is touched.