### PR TITLE
feat: add missing public JWT scopes

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -49,12 +49,16 @@ class JWTScope
     const ANTI_FRAUD_SERVICE_DEFINITIONS_WRITE = 'anti-fraud-service-definitions.write';
     const ANTI_FRAUD_SERVICES_READ = 'anti-fraud-services.read';
     const ANTI_FRAUD_SERVICES_WRITE = 'anti-fraud-services.write';
+    const API_KEY_PAIRS_READ = 'api-key-pairs.read';
+    const API_KEY_PAIRS_WRITE = 'api-key-pairs.write';
     const API_LOGS_READ = 'api-logs.read';
     const API_LOGS_WRITE = 'api-logs.write';
     const APPLE_PAY_CERTIFICATES_READ = 'apple-pay-certificates.read';
     const APPLE_PAY_CERTIFICATES_WRITE = 'apple-pay-certificates.write';
     const AUDIT_LOGS_READ = 'audit-logs.read';
     const AUDIT_LOGS_WRITE = 'audit-logs.write';
+    const BIN_CHECKER_READ = 'bin-checker.read';
+    const BIN_CHECKER_WRITE = 'bin-checker.write';
     const BUYERS_READ = 'buyers.read';
     const BUYERS_WRITE = 'buyers.write';
     const BUYERS_BILLING_DETAILS_READ = 'buyers.billing-details.read';
@@ -95,6 +99,8 @@ class JWTScope
     const REPORTS_WRITE = 'reports.write';
     const ROLES_READ = 'roles.read';
     const ROLES_WRITE = 'roles.write';
+    const THREE_DS_SCENARIOS_READ = 'three-ds-scenarios.read';
+    const THREE_DS_SCENARIOS_WRITE = 'three-ds-scenarios.write';
     const TRANSACTIONS_READ = 'transactions.read';
     const TRANSACTIONS_WRITE = 'transactions.write';
     const USERS_ME_READ = 'users.me.read';


### PR DESCRIPTION
## What

Adds three JWT scope pairs that exist in core-api's public scope set but were missing from this SDK's scope list:

- `api-key-pairs.read` / `api-key-pairs.write`
- `bin-checker.read` / `bin-checker.write`
- `three-ds-scenarios.read` / `three-ds-scenarios.write`

## Why

A merchant on the Java SDK hit this: they need to mint a JWT with `bin-checker.read`, but the scope isn't in the shipped scope enum, so there's no supported way to request it. The same three pairs were missing from all six SDKs (java, python, php, go, csharp, typescript) — matching PRs are open on each.

## How it was verified

Each scope string was checked against `RESOURCES` in core-api `src/api/helpers/auth.py`. All three are public API surface: guarded by `get_token` (not `get_staff_token`) and exposed with `include_in_schema=True`.

After this change the SDK scope list matches core-api's public scope set exactly (71 scopes, plus the `*.read` / `*.write` staff wildcards the SDKs already carried).

`business-contexts` was deliberately **not** added. It computes as public in core-api because it's flagged `internal=False`, but its endpoints require a staff token and are hidden from the schema — it looks like a stale flag in core-api rather than a genuinely public scope, and is being followed up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
