### PR TITLE
test: cover gift-card activations/issuances and authorization increment

### DIFF
--- a/Tests/Processing/GiftCardsTest.php
+++ b/Tests/Processing/GiftCardsTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Gr4vy\Tests\Processing;
 
+use Gr4vy\GiftCardActivationCreate;
 use Gr4vy\GiftCardBalanceRequest;
 use Gr4vy\GiftCardCreate;
+use Gr4vy\GiftCardIssuanceCreate;
 use Gr4vy\GiftCardRequest;
 use Gr4vy\ListGiftCardsRequest;
 use Gr4vy\Tests\Utils\MerchantTestCase;
@@ -14,8 +16,8 @@ use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Gift cards. The mock merchant has no gift-card service configured, so create /
- * balances are reached at the request level (they cleanly 4xx); list is a real
- * happy path (it returns an empty page).
+ * balances / activations / issuances are reached at the request level (they
+ * cleanly 4xx); list is a real happy path (it returns an empty page).
  */
 final class GiftCardsTest extends MerchantTestCase
 {
@@ -44,6 +46,39 @@ final class GiftCardsTest extends MerchantTestCase
                 new GiftCardBalanceRequest(items: [new GiftCardRequest(number: '4111111111111111', pin: '1234')])
             ),
             'giftCards.balances.list',
+        );
+    }
+
+    #[Test]
+    public function activation_is_reached(): void
+    {
+        $sdk = $this->sdk();
+
+        // Activating a gift card needs a configured gift-card service.
+        Reach::reaches(
+            fn () => $sdk->giftCards->activations->create(new GiftCardActivationCreate(
+                number: '4111111111111111',
+                pin: '1234',
+                amount: 1299,
+                currency: 'USD',
+            )),
+            'giftCards.activations.create',
+        );
+    }
+
+    #[Test]
+    public function issuance_is_reached(): void
+    {
+        $sdk = $this->sdk();
+
+        // Issuing a gift card needs a configured gift-card service with a theme.
+        Reach::reaches(
+            fn () => $sdk->giftCards->issuances->create(new GiftCardIssuanceCreate(
+                theme: 'default',
+                amount: 1299,
+                currency: 'USD',
+            )),
+            'giftCards.issuances.create',
         );
     }
 }

--- a/Tests/Processing/TransactionsTest.php
+++ b/Tests/Processing/TransactionsTest.php
@@ -8,6 +8,7 @@ use Gr4vy\Tests\Utils\CheckoutFields;
 use Gr4vy\Tests\Utils\Fixtures;
 use Gr4vy\Tests\Utils\MerchantTestCase;
 use Gr4vy\Tests\Utils\Reach;
+use Gr4vy\TransactionAuthorizationIncrementCreate;
 use Gr4vy\TransactionUpdate;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -80,6 +81,23 @@ final class TransactionsTest extends MerchantTestCase
         Reach::reaches(
             fn () => $sdk->transactions->refundSettlements->get($txn->id, self::MISSING_ID),
             'transactions.refundSettlements.get',
+        );
+    }
+
+    #[Test]
+    public function increment_authorization_is_reached(): void
+    {
+        $sdk = $this->sdk();
+        // Incremental authorization is a PSP capability the mock connector does
+        // not offer, so we authorize for real and accept a clean rejection.
+        $txn = CheckoutFields::authorize($sdk);
+
+        Reach::reaches(
+            fn () => $sdk->transactions->incrementAuthorization(
+                new TransactionAuthorizationIncrementCreate(amount: 500),
+                $txn->id,
+            ),
+            'transactions.incrementAuthorization',
         );
     }
 


### PR DESCRIPTION
## Why

The endpoint-reach report has been sitting at **116 / 119** on every SDK. The same three operations were never hitting the wire:

- `POST /gift-cards/activations`
- `POST /gift-cards/issuances`
- `POST /transactions/{transaction_id}/authorization/increment`

This closes the gap for PHP. Companion PRs cover the other five SDKs.

## What

- `Tests/Processing/GiftCardsTest.php` — `activation_is_reached`, `issuance_is_reached`
- `Tests/Processing/TransactionsTest.php` — `increment_authorization_is_reached`

All three need capabilities the mock-card merchant does not have (a configured gift-card service; a PSP that supports incremental authorization), so they follow the existing `Reach::reaches` convention: a 2xx or a clean 4xx passes, a **5xx fails**. The increment test authorizes a real transaction first, so the increment is attempted against a genuinely authorized transaction rather than a missing id.

## Verification

⚠️ I have no PHP runtime on this machine, so I could not run `phpunit`/`phpstan` locally — CI here is the first real check. I verified the call chains against the generated sources instead: `GiftCardsSDK::$activations`/`$issuances`, the constructor signatures and named arguments of the three component classes, and the `(body, transactionId)` argument order on `Transactions::incrementAuthorization`.

The `coverage` job is the coverage verification — it should report **119 / 119**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)